### PR TITLE
added links to SLEAP-HPC repo and slides

### DIFF
--- a/docs/source/courses/HPC-linux.md
+++ b/docs/source/courses/HPC-linux.md
@@ -57,7 +57,6 @@ effectively use the SWC/GNU High Performance Computing (HPC) system.
 - Fair use
 
 ### Applied HPC Use
-- TBC, but may include
-  - Pose estimation
-  - BrainSaw atlas registration
-  - Running custom scripts
+- Running pose estimation with SLEAP
+- [GitHub repository](https://github.com/neuroinformatics-unit/swc-hpc-pose-estimation) with example scripts
+- [Presentation slides](https://neuroinformatics-unit.github.io/swc-hpc-pose-estimation)

--- a/docs/source/courses/HPC-linux.md
+++ b/docs/source/courses/HPC-linux.md
@@ -57,6 +57,6 @@ effectively use the SWC/GNU High Performance Computing (HPC) system.
 - Fair use
 
 ### Applied HPC Use
-- Running pose estimation with SLEAP
+Running pose estimation with [SLEAP](https://sleap.ai)
 - [GitHub repository](https://github.com/neuroinformatics-unit/swc-hpc-pose-estimation) with example scripts
 - [Presentation slides](https://neuroinformatics-unit.github.io/swc-hpc-pose-estimation)


### PR DESCRIPTION
I modified the HPC-Linux course page to add links to:
- the [GitHub repository](https://github.com/neuroinformatics-unit/swc-hpc-pose-estimation) where the guides and the example scripts are hosted
- the [slides](https://neuroinformatics-unit.github.io/swc-hpc-pose-estimation) in revealjs format. The slides are currently hosted via gh-pages on the above repository. My initial plan was to directly host them in this repo, but this turned out to be quite complicated.