### PR TITLE
Add old courses to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# SWC/GCNU Software Skills
+# SWC/GCNU Software Skills website
+
+# To build locally
+```bash
+git clone https://github.com/neuroinformatics-unit/software-skills
+cd software-skills
+pip install -r docs/requirements.txt
+rm -rf docs/build
+sphinx-build docs/source docs/build
+```
+
+# To edit
+## Adding a new course:
+- Add a markdown file to the `docs/source/courses` directory (copying the structure of an existing course)
+- Add the course to the `toctree` in `docs/source/courses/index.md`
+- Add a card advertising the course in the `Upcoming courses` section of `docs/source/index.md`, using the syntax e.g.:
+```
+::::{grid} 1 2 2 3
+:gutter: 3
+
+:::{grid-item-card} {fa}`file-image;sd-text-primary` Date & Time
+:link: courses/course-name
+:link-type: doc
+
+Course title
++++
+Location <br>
+Time
+:::
+```
+
+## Once a course has run
+- Move the card from `Upcoming courses` to `Previous courses`, and remove the time/location e.g.:
+```
+::::{grid} 1 2 2 3
+:gutter: 3
+
+:::{grid-item-card} {fa}`file-image;sd-text-primary` Date & Time
+:link: courses/course-name
+:link-type: doc
+
+Course title
+:::
+
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,6 +4,9 @@ Computational skills training at the [UCL](https://www.ucl.ac.uk/)
 [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/) and [Gatsby Computational Neuroscience Unit](https://www.ucl.ac.uk/gatsby/gatsby-computational-neuroscience-unit).
 
 ## Upcoming Courses
+No courses are currently scheduled. 
+
+## Previous Courses
 
 <!--for fontawesome icons, see https://fontawesome.com/docs/web/setup/get-started-->
 ::::{grid} 1 2 2 3
@@ -14,9 +17,48 @@ Computational skills training at the [UCL](https://www.ucl.ac.uk/)
 :link-type: doc
 
 Image Analysis in Python
-+++
-SWC Lecture Theatre, UCL <br>
-1pm-5pm
+:::
+
+:::{grid-item-card} {fa}`file-image;sd-text-primary` May 30th 2023
+:link: courses/introduction-image-analysis
+:link-type: doc
+
+Introduction to Image Analysis
+:::
+
+:::{grid-item-card} {fas}`code;sd-text-primary` May 15th 2023
+:link: courses/HPC-linux
+:link-type: doc
+
+Introduction to high-performance computing with Linux
+:::
+
+:::{grid-item-card} {fas}`wave-square;sd-text-primary` March 20th 2023
+:link: courses/timeseries-analysis
+:link-type: doc
+
+Introduction to Timeseries Analysis in Python
+:::
+
+:::{grid-item-card} {fas}`code;sd-text-primary`  December 1st 2022
+:link: courses/python-packaging
+:link-type: doc
+
+Turning your Python scripts into reusable, general-purpose software
+:::
+
+:::{grid-item-card} {fas}`code;sd-text-primary`  November 25th 2022
+:link: courses/type-annotation
+:link-type: doc
+
+Type annotation in Python
+:::
+
+:::{grid-item-card} {fas}`code;sd-text-primary`  September 26th-27th 2022
+:link: courses/intro-software-dev
+:link-type: doc
+
+Introduction to Software Development in Python
 :::
 
 ::::


### PR DESCRIPTION
Closes #25 

Went for a simple system, when a course is over, we just move it from `Upcoming courses` to `Previous courses` and remove the location (making the card smaller).