### PR TITLE
Update hpc/behaviour links following repo renaming

### DIFF
--- a/docs/source/courses/collaborative-coding.md
+++ b/docs/source/courses/collaborative-coding.md
@@ -22,5 +22,5 @@ They should also follow [these setup instructions](https://github.com/rse-best-p
 
 ## Materials
 
-* [Slides](https://neuroinformatics-unit.github.io/software-good-practice-course/)
+* [Slides](https://neuroinformatics.dev/course-software-good-practice)
 * [Github repo "Playground"](https://github.com/rse-best-practices-course-2023/rse-best-practices-playground/)

--- a/docs/source/courses/hpc-behaviour.md
+++ b/docs/source/courses/hpc-behaviour.md
@@ -20,5 +20,5 @@ If you require any assistance, please contact
 
 
 ## Materials
-* [Slides](https://neuroinformatics.dev/course-behaviour-hpc/#/title-slide)
+* [Slides](https://neuroinformatics.dev/course-behaviour-hpc)
 * [GitHub repository](https://github.com/neuroinformatics-unit/course-behaviour-hpc)

--- a/docs/source/courses/hpc-behaviour.md
+++ b/docs/source/courses/hpc-behaviour.md
@@ -20,5 +20,5 @@ If you require any assistance, please contact
 
 
 ## Materials
-* [Slides](https://neuroinformatics.dev/course-software-skills-hpc/#/title-slide)
-* [GitHub repository](https://github.com/neuroinformatics-unit/course-software-skills-hpc)
+* [Slides](https://neuroinformatics.dev/course-behaviour-hpc/#/title-slide)
+* [GitHub repository](https://github.com/neuroinformatics-unit/course-behaviour-hpc)


### PR DESCRIPTION
Following https://github.com/neuroinformatics-unit/course-behaviour-hpc/issues/15