### PR TITLE
Add schedule for 2024 courses

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,6 +83,7 @@ linkcheck_anchors_ignore_for_url = [
     "https://neuroinformatics.dev/course-behavioural-analysis",
     "https://github.com/neuroinformatics-unit/course-behaviour-hpc",
     "https://neuroinformatics.dev/course-behaviour-hpc",
+    "https://github.com/conda-forge/miniforge",
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -135,4 +135,5 @@ linkcheck_ignore = [
     "https://keras.io/",
     "https://wiki.ucl.ac.uk",
     "https://www.dropbox.com",
+    "https://www.sciencedirect.com/"
 ]

--- a/docs/source/courses/histology-brainglobe.md
+++ b/docs/source/courses/histology-brainglobe.md
@@ -1,3 +1,3 @@
 # Histology analysis using napari and BrainGlobe
 
-For full details, please see the [BrainGlobe website](https://brainglobe.info/community/courses/dec-2023/index.html).
+For full details, please see the [BrainGlobe website](https://brainglobe.info/community/courses/scheduled/dec-2023/index.html).

--- a/docs/source/courses/index.md
+++ b/docs/source/courses/index.md
@@ -23,5 +23,5 @@ introduction-image-analysis.md
 intro-software-dev.md
 python-packaging.md
 type-annotation.md
-
+software-skills.md
 ```

--- a/docs/source/courses/software-skills.md
+++ b/docs/source/courses/software-skills.md
@@ -39,13 +39,13 @@ using leading open-source software tools. This course will also include some gen
 The aim of the course is to introduce basic concepts of programming in Python, and establish a community of Python users. It is a hands-on course, in which we will guide you 
 through the process of writing your first Python script and teach you some best practices.
 
-The course will run over two days.
+The course will run over two days, 2.5-3h per day with a break in between.
 
 Instructors: Igor Tatarnikov, Sofía Miñano
 
 **Day 1**
 
-Morning 
+Part 1 
 * Aims
 * Why learn Python?
 * How to work with Python?
@@ -53,7 +53,7 @@ Morning
     - Variables
     - Data types
 
-Afternoon 
+Part 2 
 * Basics of programming (2/2)
     - Loops
     - Conditional statements
@@ -64,13 +64,13 @@ Afternoon
 
 **Day 2**
 
-Morning
+Part 1
 * Recap and Q&A
 * Using third party libraries
 * Functions and methods
 * Classes and objects
 
-Afternoon
+Part 2
 * Errors and exceptions
 * Organising your code
 * Documenting your code

--- a/docs/source/courses/software-skills.md
+++ b/docs/source/courses/software-skills.md
@@ -1,0 +1,35 @@
+# General software skills for systems neuroscience
+
+## Overview
+Held over seven days, this course will provide researchers with some basic computational skills for systems 
+neuroscience research. This will include general programming, software development best practices and data analysis 
+using leading open-source software tools. This course will also include some general microscopy lectures. 
+
+## Schedule
+### Monday, September 30th
+- 13:00-14:00: Introduction to the course (SWC Brasserie Seminar Room)
+- 14:00-17:00: Introduction to Python (1) (SWC Brasserie Seminar Room)
+
+### Tuesday, October 1st
+- 10:00-11:00: Data management and sharing (1) (SWC Ground Floor Lecture Theatre)
+- 15:00-17:00: Data management and sharing (2) (SWC Ground Floor Lecture Theatre)
+
+### Wednesday, October 2nd
+- 10:00-12:30: Introduction to Python (2) (GCNU Seminar Room)
+- 13:30-17:00: Version control and software development best practices (GCNU Seminar Room)
+
+### Thursday, October 3rd
+- 10:00-13:00: Video behavioural analysis (1) (SWC Brasserie Seminar Room)
+- 14:00-17:00: Video behavioural analysis (2) (SWC Brasserie Seminar Room)
+
+### Friday, October 4th
+- 14:00-17:00: Linux and high-performance computing (SWC Ground Floor Lecture Theatre)
+
+### Monday, October 7th
+- 11:00-12:00: General microscopy: basics (SWC Brasserie Seminar Room)
+- 13:00-14:30: General microscopy: applications (SWC Brasserie Seminar Room)
+- 14:30-18:00: Histology analysis (1) (SWC Brasserie Seminar Room)
+
+### Tuesday, October 8th
+- 10:00-11:00: Histology analysis (2) (SWC Ground Floor Lecture Theatre)
+- 14:00-17:00: Histology analysis (3)  (SWC Brasserie Seminar Room)

--- a/docs/source/courses/software-skills.md
+++ b/docs/source/courses/software-skills.md
@@ -33,3 +33,55 @@ using leading open-source software tools. This course will also include some gen
 ### Tuesday, October 8th
 - 10:00-11:00: Histology analysis (2) (SWC Ground Floor Lecture Theatre)
 - 14:00-17:00: Histology analysis (3)  (SWC Brasserie Seminar Room)
+
+
+## Introduction to Python
+The aim of the course is to introduce basic concepts of programming in Python, and establish a community of Python users. It is a hands-on course, in which we will guide you 
+through the process of writing your first Python script and teach you some best practices.
+
+The course will run over two days.
+
+Instructors: Igor Tatarnikov, Sofía Miñano
+
+**Day 1**
+
+Morning 
+* Aims
+* Why learn Python?
+* How to work with Python?
+* Basics of programming (1/2)
+    - Variables
+    - Data types
+
+Afternoon 
+* Basics of programming (2/2)
+    - Loops
+    - Conditional statements
+    - List comprehensions
+* Writing your first Python script
+* Loading and saving data
+
+
+**Day 2**
+
+Morning
+* Recap and Q&A
+* Using third party libraries
+* Functions and methods
+* Classes and objects
+
+Afternoon
+* Errors and exceptions
+* Organising your code
+* Documenting your code
+
+
+### Course materials
+- [Slides](https://docs.google.com/presentation/d/11URuWOxi5TMbeJNo4R1NWfBQ_ZPNFpe6YU6dvLAVcYQ/edit?usp=sharing)
+- [Site for the 2023/2024 course](https://software-skills.neuroinformatics.dev/courses/intro-software-dev.html)
+
+
+### Additional resources
+- [Miniforge installers](https://github.com/conda-forge/miniforge#download)
+- [PyCharm](https://www.jetbrains.com/pycharm/)  
+- [VS Code](https://code.visualstudio.com/)  

--- a/docs/source/courses/software-skills.md
+++ b/docs/source/courses/software-skills.md
@@ -19,8 +19,8 @@ using leading open-source software tools. This course will also include some gen
 - 13:30-17:00: Version control and software development best practices (GCNU Seminar Room)
 
 ### Thursday, October 3rd
-- 10:00-13:00: Video behavioural analysis (1) (SWC Brasserie Seminar Room)
-- 14:00-17:00: Video behavioural analysis (2) (SWC Brasserie Seminar Room)
+- 10:00-13:00: Video-based analysis of animal behaviour (1) (SWC Brasserie Seminar Room)
+- 14:00-17:00: Video-based analysis of animal behaviour (2) (SWC Brasserie Seminar Room)
 
 ### Friday, October 4th
 - 14:00-17:00: Linux and high-performance computing (SWC Ground Floor Lecture Theatre)
@@ -102,6 +102,17 @@ The aims of the course are
 * and to get an initial idea of how structure, document and test your code.
 
 Instructors: Stephen Lenzi, Laura Porta, Alessandro Felder
+
+## Video-based analysis of animal behaviour
+
+This course will introduce the theory and practice of tracking animals in videos to quantify their behaviour.
+Participants will get to train pose estimation models
+with [SLEAP](https://sleap.ai/), analyse pose tracks
+with [movement](https://movement.neuroinformatics.dev/), and extract behavioural syllables with [keypoint-moseq](https://keypoint-moseq.readthedocs.io/en/latest/index.html). 
+
+Full details can be found on the [course webpage](video-analysis).
+
+Instructors: Niko Sirmpilatze, Chang Huan Lo, Sofía Miñano
 
 ## Histology analysis
 

--- a/docs/source/courses/software-skills.md
+++ b/docs/source/courses/software-skills.md
@@ -88,8 +88,8 @@ Part 2
 
 ## Data Management and Sharing
 
- This course will introduce current best-practices in neuroscience data management 
- and recent standardisation initiatives. The primary take-away from this course 
- will be to leave with a strong schema in mind for clean organisation of experimental project data.
+ This course will introduce best-practices in neuroscience data management 
+ and cover recent standardisation initiatives. The primary take-away from this course 
+ will be to leave with a strong schema in mind for clean organisation of experimental data.
 
 Full details can be found on the [course webpage](https://software-skills.neuroinformatics.dev/courses/data-management.html)

--- a/docs/source/courses/software-skills.md
+++ b/docs/source/courses/software-skills.md
@@ -93,3 +93,12 @@ Part 2
  will be to leave with a strong schema in mind for clean organisation of experimental data.
 
 Full details can be found on the [course webpage](https://software-skills.neuroinformatics.dev/courses/data-management.html)
+
+## Version control and software development best practices
+
+The aims of the course are
+* to learn how to keep track of changes to your code with Git and GitHub, 
+* to learn how to work with others on code
+* and to get an initial idea of how structure, document and test your code.
+
+Instructors: Stephen Lenzi, Laura Porta, Alessandro Felder

--- a/docs/source/courses/software-skills.md
+++ b/docs/source/courses/software-skills.md
@@ -85,3 +85,11 @@ Part 2
 - [Miniforge installers](https://github.com/conda-forge/miniforge#download)
 - [PyCharm](https://www.jetbrains.com/pycharm/)  
 - [VS Code](https://code.visualstudio.com/)  
+
+## Data Management and Sharing
+
+ This course will introduce current best-practices in neuroscience data management 
+ and recent standardisation initiatives. The primary take-away from this course 
+ will be to leave with a strong schema in mind for clean organisation of experimental project data.
+
+Full details can be found on the [course webpage](https://software-skills.neuroinformatics.dev/courses/data-management.html)

--- a/docs/source/courses/software-skills.md
+++ b/docs/source/courses/software-skills.md
@@ -102,3 +102,7 @@ The aims of the course are
 * and to get an initial idea of how structure, document and test your code.
 
 Instructors: Stephen Lenzi, Laura Porta, Alessandro Felder
+
+## Histology analysis
+
+Full details can be found on the [course webpage](https://brainglobe.info/community/courses/scheduled/oct-2024/index.html).

--- a/docs/source/courses/software-skills.md
+++ b/docs/source/courses/software-skills.md
@@ -6,33 +6,22 @@ neuroscience research. This will include general programming, software developme
 using leading open-source software tools. This course will also include some general microscopy lectures. 
 
 ## Schedule
-### Monday, September 30th
-- 13:00-14:00: Introduction to the course (SWC Brasserie Seminar Room)
-- 14:00-17:00: Introduction to Python (1) (SWC Brasserie Seminar Room)
-
-### Tuesday, October 1st
-- 10:00-11:00: Data management and sharing (1) (SWC Ground Floor Lecture Theatre)
-- 15:00-17:00: Data management and sharing (2) (SWC Ground Floor Lecture Theatre)
-
-### Wednesday, October 2nd
-- 10:00-12:30: Introduction to Python (2) (GCNU Seminar Room)
-- 13:30-17:00: Version control and software development best practices (GCNU Seminar Room)
-
-### Thursday, October 3rd
-- 10:00-13:00: Video-based analysis of animal behaviour (1) (SWC Brasserie Seminar Room)
-- 14:00-17:00: Video-based analysis of animal behaviour (2) (SWC Brasserie Seminar Room)
-
-### Friday, October 4th
-- 14:00-17:00: Linux and high-performance computing (SWC Ground Floor Lecture Theatre)
-
-### Monday, October 7th
-- 11:00-12:00: General microscopy: basics (SWC Brasserie Seminar Room)
-- 13:00-14:30: General microscopy: applications (SWC Brasserie Seminar Room)
-- 14:30-18:00: Histology analysis (1) (SWC Brasserie Seminar Room)
-
-### Tuesday, October 8th
-- 10:00-11:00: Histology analysis (2) (SWC Ground Floor Lecture Theatre)
-- 14:00-17:00: Histology analysis (3)  (SWC Brasserie Seminar Room)
+| Date                  | Time           | Event                                                        | Location                           |
+|-----------------------|----------------|--------------------------------------------------------------|------------------------------------|
+| **Monday, September 30th** | 13:00-14:00    | Introduction to the course                                    | SWC Brasserie Seminar Room         |
+|                       | 14:00-17:00    | Introduction to Python (1)                                    | SWC Brasserie Seminar Room         |
+| **Tuesday, October 1st**   | 10:00-11:00    | Data management and sharing (1)                                | SWC Ground Floor Lecture Theatre   |
+|                       | 15:00-17:00    | Data management and sharing (2)                                | SWC Ground Floor Lecture Theatre   |
+| **Wednesday, October 2nd** | 10:00-12:30    | Introduction to Python (2)                                    | GCNU Seminar Room                  |
+|                       | 13:30-17:00    | Version control and software development best practices       | GCNU Seminar Room                  |
+| **Thursday, October 3rd**  | 10:00-13:00    | Video-based analysis of animal behaviour (1)                  | SWC Brasserie Seminar Room         |
+|                       | 14:00-17:00    | Video-based analysis of animal behaviour (2)                  | SWC Brasserie Seminar Room         |
+| **Friday, October 4th**    | 14:00-17:00    | Linux and high-performance computing                          | SWC Ground Floor Lecture Theatre   |
+| **Monday, October 7th**    | 11:00-12:00    | General microscopy: basics                                    | SWC Brasserie Seminar Room         |
+|                       | 13:00-14:30    | General microscopy: applications                              | SWC Brasserie Seminar Room         |
+|                       | 14:30-18:00    | Histology analysis (1)                                        | SWC Brasserie Seminar Room         |
+| **Tuesday, October 8th**   | 10:00-11:00    | Histology analysis (2)                                        | SWC Ground Floor Lecture Theatre   |
+|                       | 14:00-17:00    | Histology analysis (3)                                        | SWC Brasserie Seminar Room         |
 
 
 ## Introduction to Python

--- a/docs/source/courses/video-analysis.md
+++ b/docs/source/courses/video-analysis.md
@@ -1,3 +1,4 @@
+(#video-analysis)=
 # Video-based analysis of animal behaviour
 
 ## Overview

--- a/docs/source/courses/video-analysis.md
+++ b/docs/source/courses/video-analysis.md
@@ -3,26 +3,24 @@
 ## Overview
 This will be an introductory course on analysing animal behaviour from video data. The course will cover:
 
-- Motivation
-- Overview of animal tracking methods and terminology
-- Pose estimation and tracking
-  - Overview of existing tools
-  - Labeling animal body parts
-  - Training a model
-  - Predicting poses
-  - Evaluating performance
-- Analysing pose tracks with Python
-  - Loading and saving data
-  - Filtering/smoothing
-  - Visualising tracks
-  - Time spent in regions of interest
+- Overview of animal tracking methods and terminology.
+- **Pose estimation and tracking with [SLEAP](https://sleap.ai/)**. This includes hands-on practice with training a pose estimation model, evaluating its performance, and using it to predict pose tracks in new videos.
+- **Analysing pose tracks with [movement](https://movement.neuroinformatics.dev/)**. This includes loading the predicted pose tracks in Python, filtering and smoothing them, computing kinematic variables, and visualising the results.
+- **Extracting behavioural syllables with [keypoint-moseq](https://keypoint-moseq.readthedocs.io/en/latest/index.html)**.
 
+:::{note}
 Training and prediction with pose estimation models are
 GPU-intensive tasks.
 Since many students will not have access to a GPU on their own machine, 
 we highly recommend that they also attend the follow-up course on 
 [Running pose estimation on the SWC HPC system](./hpc-behaviour). 
 This will cover how to run pose estimation at scale, using the GPUs of the SWC HPC cluster.
+:::
+
+## Instructors
+* [Niko Sirmpilatze ](https://github.com/niksirbi)
+* [Chang Huan Lo](https://github.com/lochhh)
+* [Sofía Miñano](https://github.com/sfmig)
 
 ## Prerequisites
 Make sure to follow the [steps outlined here](https://github.com/neuroinformatics-unit/course-behavioural-analysis#prerequisites) which will guide you through
@@ -31,19 +29,15 @@ setting up your laptop, installing the required software, and downloading the sa
 If you encounter issues with any of these steps please contact 
 <a href="mailto:n.sirmpilatze@ucl.ac.uk?subject=SWC/GCNU Software Skills">Niko Sirmpilatze</a>
 in advance of the course.
-You may also drop by our office hours at the SWC Library (5th floor) on **Friday Nov 24th, 13:30-16:00**.
-
 
 ## Materials
 - [GitHub repository](https://github.com/neuroinformatics-unit/course-behavioural-analysis)
 - [Slides](https://neuroinformatics.dev/course-behavioural-analysis/#/title-slide)
-- [Sample data](https://www.dropbox.com/scl/fo/ey7b6yrqax2olqyv1th7j/h?rlkey=u4wh2gxtbbn4g5o3s55zbx6pp&dl=0) - link expires on 2023-12-22
+- [Sample data](https://www.dropbox.com/scl/fo/ey7b6yrqax2olqyv1th7j/h?rlkey=u4wh2gxtbbn4g5o3s55zbx6pp&st=3yjlu70e&dl=0)
 
 Useful links:
-- [miniconda](https://docs.conda.io/en/latest/miniconda.html)
 - [SLEAP](https://sleap.ai/)
 - [DeepLabCut](https://www.mackenziemathislab.org/deeplabcut)
-- [LightningPose](https://github.com/danbider/lightning-pose)
 - [movement](https://movement.neuroinformatics.dev/)
 - [keypoint-moseq](https://keypoint-moseq.readthedocs.io/en/latest/index.html)
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -6,36 +6,20 @@ Computational skills training at the [UCL](https://www.ucl.ac.uk/)
 the [Neuroinformatics Unit](https://neuroinformatics.dev).
 
 ## Upcoming Courses
+::::{grid} 1 2 2 2
+:gutter: 3
 
-No courses are currently scheduled. 
 
-[//]: # (::::{grid} 1 2 2 2)
+:::{grid-item-card} {fas}`server;sd-text-primary`  September 30th - October 8th 2024
+:link: courses/software-skills
+:link-type: doc
 
-[//]: # (:gutter: 3)
+General software skills for systems neuroscience
++++
+Sainsbury Wellcome Centre, UCL <br>
+:::
 
-[//]: # ()
-[//]: # ()
-[//]: # (:::{grid-item-card} {fas}`server;sd-text-primary` Date)
-
-[//]: # (:link: courses/course-file)
-
-[//]: # (:link-type: doc)
-
-[//]: # ()
-[//]: # (Course title)
-
-[//]: # (+++)
-
-[//]: # (Sainsbury Wellcome Centre, UCL <br>)
-
-[//]: # (Room)
-
-[//]: # ()
-[//]: # (Time)
-
-[//]: # (:::)
-
-[//]: # (::::)
+::::
 
 ## Previous Courses
 


### PR DESCRIPTION
@neuroinformatics-unit/neuroinformatics-core 

I've raised this PR to add the information for the 2024 courses we're giving. I decided to make a single course listing the schedule for all the material we're giving (creating 8 courses seemed a bit much). 

Could you all flesh out the website with more details on each course as you have it (content, materials etc). I guess this can be either:
- Details on the main schedule page
- A link to an existing/new course page

It would be good to get this fleshed out soon so we can start advertising.