### PR TITLE
Schedule for day 1 only mentions intro to python

### DIFF
--- a/docs/source/courses/image-analysis-python.md
+++ b/docs/source/courses/image-analysis-python.md
@@ -25,8 +25,8 @@ If time allows, we will also look at using convolutional neural networks for tri
 ## In advance of the course
 ### Installing packages
 
-Before attending the course, please 
-[install conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) 
+Before attending the course, please download and install conda from
+[miniforge](https://github.com/conda-forge/miniforge) 
 if you don't already have it installed, and then run the following to install all relevant packages:
 
 ```bash

--- a/docs/source/courses/software-skills.md
+++ b/docs/source/courses/software-skills.md
@@ -9,8 +9,7 @@ using leading open-source software tools. This course will also include some gen
 ## Schedule
 | Date                  | Time           | Event                                                        | Location                           |
 |-----------------------|----------------|--------------------------------------------------------------|------------------------------------|
-| **Monday, September 30th** | 13:00-14:00    | Introduction to the course                                    | SWC Brasserie Seminar Room         |
-|                       | 14:00-17:30    | Introduction to Python (1)                                    | SWC Brasserie Seminar Room         |
+| **Monday, September 30th** | 13:00-17:30    | Introduction to Python (1)                                    | SWC Brasserie Seminar Room         |
 | **Tuesday, October 1st**   | 10:00-11:00    | Data management and sharing (1)                                | SWC Ground Floor Lecture Theatre   |
 |                       | 15:00-17:30    | Data management and sharing (2)                                | SWC Ground Floor Lecture Theatre   |
 | **Wednesday, October 2nd** | 10:00-12:30    | Introduction to Python (2)                                    | GCNU Seminar Room                  |


### PR DESCRIPTION
This is to make sure that everyone who registered for that course shows up in time for the setup.

Incidentally, I also had to fix a broken conda-install link from a past course, because it was making CI fail.