### PR TITLE
Updates for Ephys course

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -136,5 +136,4 @@ linkcheck_ignore = [
     "https://wiki.ucl.ac.uk",
     "https://www.dropbox.com",
     "https://neuroinformatics.dev/slides-SWC-PhD-intro/#/section",
-    "https://opensource.org/license/BSD-3-Clause",
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -136,4 +136,5 @@ linkcheck_ignore = [
     "https://wiki.ucl.ac.uk",
     "https://www.dropbox.com",
     "https://neuroinformatics.dev/slides-SWC-PhD-intro/#/section",
+    "https://opensource.org/license/BSD-3-Clause",
 ]

--- a/docs/source/courses/extracellular-analysis.md
+++ b/docs/source/courses/extracellular-analysis.md
@@ -23,14 +23,14 @@ Students should bring their own laptop with Python installed. If you require any
 <a href="mailto:j.ziminski@ucl.ac.uk?subject=SWC/GCNU Software Skills">Joe Ziminski</a> in advance of the course.
 
 ## Materials
-Wednesday 8th Nov
+Tuesday 5th Nov
 
 * [Slides](https://docs.google.com/presentation/d/1VTX5mogZXG-9ssQRjg3d0SCZ_jgR800KfvNfVZOhkUs/edit?usp=sharing)
 
 * [Download Data](https://www.dropbox.com/sh/h782frjxyugifle/AABANGRWOGrtUmpWkJvHON9Ya?dl=0)
  
-Thursday 9th Nov
+6th - 7th November
 
-* [Slides](https://docs.google.com/presentation/d/1qS-Ua1qbegiHr-_wCDjGk1dW6ydw09YYdpP0FJpilcQ/edit?usp=drive_link)
+* [Slides](https://docs.google.com/presentation/d/1_GMxwcyVmpvXq4BpUYwgDgEKsr23Ifl1oc0mRyWB25s/edit?usp=sharing)
 
-* [Repo](https://github.com/neuroinformatics-unit/extracellular-ephys-analysis-course-2023)
+* [Repo](https://github.com/neuroinformatics-unit/course-extracellular-ephys-analysis)

--- a/docs/source/courses/python-packaging.md
+++ b/docs/source/courses/python-packaging.md
@@ -20,7 +20,7 @@ For this course you will need a very basic knowledge of Python, and a laptop wit
 
 
 * [Sample .gitignore file](https://gist.githubusercontent.com/adamltyson/4d2b2cab224aeb94701fdddc4b894206/raw/998471179d290cf9204eb8cfe799dc32ef92e292/.gitignore)
-* [BSD-3-Clause license](https://opensource.org/licenses/BSD-3-Clause)
+* [BSD-3-Clause license](https://opensource.org/license/BSD-3-Clause)
 * [GitHub markdown guide](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
 * [black config](https://gist.githubusercontent.com/adamltyson/559678f224ae0e1f08cf1768b319793c/raw/db170fde3be3e8511b987fd019d420a52edfb9b9/pyproject.toml)
 * [pre-commit config file](https://gist.githubusercontent.com/adamltyson/06dc8f8760feee57a4b41aa66833c835/raw/da2050d7eb4db28f17d28f591fa6eefd98946408/.pre-commit-config.yaml)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -9,14 +9,12 @@ the [Neuroinformatics Unit](https://neuroinformatics.dev).
 ::::{grid} 1 2 2 2
 :gutter: 3
 
-
-:::{grid-item-card} {fas}`server;sd-text-primary`  September 30th - October 8th 2024
-:link: courses/software-skills
+:::{grid-item-card} {fas}`bolt;sd-text-primary`  Extracellular electrophysiology analysis
+:link: courses/extracellular-analysis
 :link-type: doc
 
-General software skills for systems neuroscience
-+++
-Sainsbury Wellcome Centre, UCL <br>
+November 5th - October 7th 2024
+
 :::
 
 ::::
@@ -26,6 +24,14 @@ Sainsbury Wellcome Centre, UCL <br>
 <!--for fontawesome icons, see https://fontawesome.com/docs/web/setup/get-started-->
 ::::{grid} 1 2 2 3
 :gutter: 3
+
+:::{grid-item-card} {fas}`server;sd-text-primary`  General software skills for systems neuroscience
+:link: courses/software-skills
+:link-type: doc
+
++++
+Sainsbury Wellcome Centre, UCL <br>
+:::
 
 :::{grid-item-card} {fas}`server;sd-text-primary`  Running pose estimation on the SWC HPC system
 :link: courses/hpc-behaviour
@@ -44,11 +50,6 @@ Sainsbury Wellcome Centre, UCL <br>
 
 :::{grid-item-card} {fas}`file-image;sd-text-primary`  Multiphoton imaging analysis
 :link: courses/multiphoton-analysis
-:link-type: doc
-:::
-
-:::{grid-item-card} {fas}`bolt;sd-text-primary`  Extracellular electrophysiology analysis
-:link: courses/extracellular-analysis
 :link-type: doc
 :::
 


### PR DESCRIPTION
This PR
- removes the general software course to the past course, closing #68 
- updates the ephys course information

EDIT: as part of this PR I had to ignore `https://opensource.org/license/BSD-3-Clause` because even though the link seems fine, it is erroring out on the CI.

![image](https://github.com/user-attachments/assets/c94825a0-c9dd-4ef0-acd6-6d288b2023e5)
