### PR TITLE
Update behaviour course description for Oct 2025

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -133,7 +133,6 @@ html_theme_options = {
 
 linkcheck_ignore = [
     "https://keras.io/",
-    "https://wiki.ucl.ac.uk",
     "https://www.dropbox.com",
     "https://neuroinformatics.dev/slides-SWC-PhD-intro/#/section",
     "https://opensource.org/license/BSD-3-Clause",

--- a/docs/source/courses/hpc-behaviour.md
+++ b/docs/source/courses/hpc-behaviour.md
@@ -9,7 +9,7 @@ an understanding of pose estimation tools, e.g. by attending the [Video-based an
 
 Students should bring their own laptop with Python installed. They should also possess
 an SWC username and password and be able to 
-[log into the SWC's HPC cluster](https://wiki.ucl.ac.uk/display/SSC/Logging+into+the+Cluster).
+[log into the SWC's HPC cluster](https://liveuclac.sharepoint.com/sites/SSC/SitePages/SSC-Logging-into-the-Cluster-194972967.aspx).
 If you require any assistance, please contact
 <a href="mailto:adam.tyson@ucl.ac.uk?subject=SWC/GCNU Software Skills">Adam Tyson</a> in advance of the course.
 

--- a/docs/source/courses/video-analysis.md
+++ b/docs/source/courses/video-analysis.md
@@ -2,16 +2,16 @@
 # Video-based analysis of animal behaviour
 
 ## Overview
-This will be an introductory course on analysing animal behaviour from video data. The course will cover:
+This course introduces free, open-source tools for tracking animal motion from videos and extracting quantitative descriptions of behaviour from motion tracks.
 
-- Overview of animal tracking methods and terminology.
-- **Pose estimation and tracking with [SLEAP](https://sleap.ai/)**. This includes hands-on practice with training a pose estimation model, evaluating its performance, and using it to predict pose tracks in new videos.
-- **Analysing pose tracks with [movement](https://movement.neuroinformatics.dev/)**. This includes loading the predicted pose tracks in Python, filtering and smoothing them, computing kinematic variables, and visualising the results.
-- **Extracting behavioural syllables with [keypoint-moseq](https://keypoint-moseq.readthedocs.io/en/latest/index.html)**.
+We'll be going through the following chapters of the ['Animals in Motion' handbook](https://animals-in-motion.neuroinformatics.dev/latest/):
+
+- [Chapter 1: Introduction](https://animals-in-motion.neuroinformatics.dev/latest/01-intro.html)
+- [Chapter 3: Pose Estimation with SLEAP](https://animals-in-motion.neuroinformatics.dev/latest/03-sleap-tutorial.html). Hands-on practice with [SLEAP](https://sleap.ai/) to train a pose estimation model, evaluate its performance, and use it to predict poses on new video frames.
+- [Chanpter 4: Analysing tracks with movement](https://animals-in-motion.neuroinformatics.dev/latest/04-movement-intro.html). Hands on practice with [movement](https://movement.neuroinformatics.dev/) to load predicted pose tracks in Python, clean them, compute kinematic variables, and visualise the results.
 
 :::{note}
-Training and prediction with pose estimation models are
-GPU-intensive tasks.
+Training and prediction with pose estimation models are GPU-intensive tasks.
 Since many students will not have access to a GPU on their own machine, 
 we highly recommend that they also attend the follow-up course on 
 [Running pose estimation on the SWC HPC system](./hpc-behaviour). 
@@ -25,61 +25,16 @@ This will cover how to run pose estimation at scale, using the GPUs of the SWC H
 
 ## Prerequisites
 
-### Hardware Requirements
+Please carefully read through the [prerequisites page of the 'Animals in Motion' handbook](https://animals-in-motion.neuroinformatics.dev/latest/prerequisites.html), listing  hardware, software, and data requirements.
+**Make sure to set aside half an hour ahead of the course to install the necessary software and download the sample data.**
 
-This is a hands-on course, so **please bring your own laptop and charger**. A mouse is recommended but not essential. A dedicated GPU is not required but will be helpful.
-
-### General Software Requirements
-
-:::{note}
-If you are an incoming PhD student attending the full [General Software Skills for Systems Neuroscience](general-software-skills) course and have already installed the general software requirements on Day 1, you may skip this section.
-:::
-
-- An IDE for Python programming. We recommend one of the following:
-  - [Visual Studio Code](https://code.visualstudio.com/) with the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-  - [PyCharm](https://www.jetbrains.com/pycharm/)
-  - [JupyterLab](https://jupyter.org/install)
-
-- A working `conda` (or `mamba`) installation. If you don't have it, install via [Miniforge](https://github.com/conda-forge/miniforge).
-- A working [Git](https://git-scm.com/) installation.
-
-### Specific Software Requirements
+If you encounter any installation issues, please contact **Niko Sirmpilatze**.
 
 :::{note}
-Only proceed with this section after fulfilling the general software requirements above.
+If you are an incoming PhD student attending the full [General Software Skills for Systems Neuroscience](general-software-skills) course you will have likely already installed [general development tools](https://animals-in-motion.neuroinformatics.dev/latest/prerequisites.html#sec-install-devtools) so you may skip that section of the prerequisites.
 :::
 
-You will need to pre-install two different `conda` environments for the practical exercises. Create them as follows:
-
-1. [**SLEAP**](https://sleap.ai/): Use the [conda package method](https://sleap.ai/installation.html#conda-package) from the SLEAP installation guide. You may use either `conda` or `mamba` in the installation command. An NVIDIA GPU is not required for this course as you will only use the SLEAP GUI (launched using `sleap-label`).
-2. [**Keypoint-MoSeq**](https://keypoint-moseq.readthedocs.io): Use the recommended [conda installation method](https://keypoint-moseq.readthedocs.io/en/latest/install.html#install-using-conda).
-
-You should now have two new conda environments called `sleap` and `keypoint_moseq`. To view all your conda environments, run `conda env list`.
-
-### Sample Data
-
-Download the sample data for this course from https://tinyurl.com/behav-analysis-course-data. Click "Download" to get the `behav-analysis-course.zip` archive, then unzip it.
-
-Alternatively, if you are connected to the SWC network and have access to the SWC's `ceph` filesystem, the dataset is available at `/ceph/scratch/neuroinformatics-dropoff/behav-analysis-course`. 
-Ensure you copy the data to a convenient location on your laptop. 
-The instructions to mount `ceph` on your laptop can be found on the [SWC wiki](https://wiki.ucl.ac.uk/display/SSC/Storage%3A+Ceph).
-
-:::{note}
-If you encounter any issues with these steps, please contact [Niko Sirmpilatze](mailto:n.sirmpilatze@ucl.ac.uk?subject=SWC/GCNU%20Software%20Skills) in advance of the course.
-:::
 
 ## Materials
-- [GitHub repository](https://github.com/neuroinformatics-unit/course-behavioural-analysis)
-- [Slides](https://neuroinformatics.dev/course-behavioural-analysis/#/title-slide)
-- [Sample data](https://tinyurl.com/behav-analysis-course-data)
-
-Useful links:
-- [SLEAP](https://sleap.ai/)
-- [DeepLabCut](https://www.mackenziemathislab.org/deeplabcut)
-- [movement](https://movement.neuroinformatics.dev/)
-- [keypoint-moseq](https://keypoint-moseq.readthedocs.io/en/latest/index.html)
-
-Recommended readings:
-- [Neuroscience Needs Behavior: Correcting a Reductionist Bias](http://dx.doi.org/10.1016/j.neuron.2016.12.041)
-- [Quantifying behavior to understand the brain](https://www.nature.com/articles/s41593-020-00734-z)
-- [Open-source tools for behavioral video analysis: Setup, methods, and best practices](https://elifesciences.org/articles/79305)
+- ['Animals in Motion' handbook](https://animals-in-motion.neuroinformatics.dev/latest/)
+- [GitHub repository](https://github.com/neuroinformatics-unit/course-animals-in-motion)


### PR DESCRIPTION
See also #73 where the course schedule is updated.

I updated the video analysis course description by deleting much of its previous contents and pointing to "Animals in Motion" as the source of truth, including for the prerequisites.

The "Animals in Motion" links point to <https://animals-in-motion.neuroinformatics.dev/latest/>, which currently is the same as `v2025.08` but will become `v2025.10` in the next couple of days (pending a new release of "Animals in Motion").

I also updated the link to the SWC wiki in the HPC behaviour course's description.

Linkcheck failures are unrelated to this PR.